### PR TITLE
Fix pg exporter limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Enhancements:
   * switch to using original `logical-backup` v1.15.1 image
 * `postgres-exporter` update 0.17.1 -> 0.18.1
 
+# 10.11.1
+
+Enhancements:
+* increased `postgres exporter` memory limit 50Mi -> 200Mi
+
 # 10.11.0
 
 Enhancements:

--- a/charts/chart_deps/postgres/postgres-cluster/templates/_helpers.tpl
+++ b/charts/chart_deps/postgres/postgres-cluster/templates/_helpers.tpl
@@ -65,7 +65,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   resources:
     limits:
       cpu: 400m
-      memory: 50Mi
+      memory: 200Mi
     requests:
       cpu: 10m
       memory: 15Mi


### PR DESCRIPTION
Enhancements:
* increased `postgres exporter` memory limit 50Mi -> 200Mi