### PR TITLE
Gha no volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Enchancements:
   * add `workflow` pod `resources requests`
   * add default `serviceAccountName` for `workflow` pods
   * `workflowConfigMap` is enabled when `gha-runner.enabled` = true
+* set default `secret and serviceAccount` for `gl-runner-app` runner pod
 
 Fixes:
 * `gha-runner/gha-runner-app`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,30 @@ Fixes
     * `Table disk block reads per second ` shows only master pod info
     * `DB Commits per second` shows only master pod info
 
+# 10.13.0
+
+New features:
+* new app `gha-runner-app` and `gl-runner-app` in `charts/environment`
+
+Enchancements:
+* `gha-operator`:
+  * `crds` update 0.13.1 -> 0.14.2
+  * `chart` update 0.13.0 -> 0.14.2
+* `gha-runner`:
+  * `chart` update 0.13.0 -> 0.14.2
+  * use `kubernetes-novolume` mode instead of `kubernetes`
+  * delete `gha-runner storage`
+  * set default `githubConfigSecret` = github
+  * add `runner` pod `resources requests/limits`
+  * add `workflow` pod `resources requests`
+  * add default `serviceAccountName` for `workflow` pods
+  * `workflowConfigMap` is enabled when `gha-runner.enabled` = true
+
+Fixes:
+* `gha-runner/gha-runner-app`:
+  * delete hardcode `runnerScaleSetName`, for correct names template
+  * set default `argocd.argoproj.io/tracking-id` in `autoscalingListener` and `pod/listener` for correct tracking in argocd
+
 # 10.12.1
 
 New features:

--- a/charts/environment/templates/chart_apps.yaml
+++ b/charts/environment/templates/chart_apps.yaml
@@ -4,6 +4,19 @@
 {{- $chart_path := ternary $.Values.repository.paths.app_charts $.Values.repository.paths.charts (eq $chart_app_obj.app true) }}
 {{- $env_path := ternary $.Values.repository.paths.env_from_app_charts $.Values.repository.paths.env_from_charts (eq $chart_app_obj.app true) }}
 {{- $globals_path := ternary $.Values.repository.paths.globals_from_app_charts $.Values.repository.paths.globals_from_charts (eq $chart_app_obj.app true) }}
+{{- $chart_override := "" }}
+{{- with $chart_app_obj.chart }}
+{{- $chart_override = tpl . $ }}
+{{- end }}
+{{- $is_gha_runner := or (eq $chart_app_name "gha-runner") (eq $chart_override "gha-runner") (hasSuffix "/gha-runner" $chart_override) }}
+{{- $values_object := dict }}
+{{- if $is_gha_runner }}
+{{- $tracking_id := printf "%s:argoproj.io/Application:argocd/%s" $app_name $app_name }}
+{{- $values_object = dict "gha-runner" (dict "resourceMeta" (dict "autoscalingListener" (dict "annotations" (dict "argocd.argoproj.io/tracking-id" $tracking_id))) "listenerTemplate" (dict "metadata" (dict "annotations" (dict "argocd.argoproj.io/tracking-id" $tracking_id)))) }}
+{{- end }}
+{{- with $chart_app_obj.valuesObject }}
+{{- $values_object = mergeOverwrite $values_object (tpl (toYaml .) $ | fromYaml) }}
+{{- end }}
 {{- if $chart_app_obj.enabled -}}
 ---
 apiVersion: argoproj.io/v1alpha1
@@ -60,9 +73,9 @@ spec:
       parameters:
     {{- tpl (toYaml .) $ | nindent 8 }}
     {{- end }}
-    {{- with $chart_app_obj.valuesObject }}
+    {{- with $values_object }}
       valuesObject:
-    {{- tpl (toYaml .) $ | nindent 8 }}
+    {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- if $chart_app_obj.values }}
       values: {{ tpl (toYaml $chart_app_obj.values) $ | nindent 8 }}
@@ -101,9 +114,9 @@ spec:
       parameters:
     {{- tpl (toYaml .) $ | nindent 8 }}
     {{- end }}
-    {{- with $chart_app_obj.valuesObject }}
+    {{- with $values_object }}
       valuesObject:
-    {{- tpl (toYaml .) $ | nindent 8 }}
+    {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- if $chart_app_obj.values }}
       values: {{ tpl (toYaml $chart_app_obj.values) $ | nindent 8 }}

--- a/charts/environment/templates/chart_apps.yaml
+++ b/charts/environment/templates/chart_apps.yaml
@@ -8,12 +8,7 @@
 {{- with $chart_app_obj.chart }}
 {{- $chart_override = tpl . $ }}
 {{- end }}
-{{- $is_gha_runner := or (eq $chart_app_name "gha-runner") (eq $chart_override "gha-runner") (hasSuffix "/gha-runner" $chart_override) }}
 {{- $values_object := dict }}
-{{- if $is_gha_runner }}
-{{- $tracking_id := printf "%s:argoproj.io/Application:argocd/%s" $app_name $app_name }}
-{{- $values_object = dict "gha-runner" (dict "resourceMeta" (dict "autoscalingListener" (dict "annotations" (dict "argocd.argoproj.io/tracking-id" $tracking_id))) "listenerTemplate" (dict "metadata" (dict "annotations" (dict "argocd.argoproj.io/tracking-id" $tracking_id)))) }}
-{{- end }}
 {{- with $chart_app_obj.valuesObject }}
 {{- $values_object = mergeOverwrite $values_object (tpl (toYaml .) $ | fromYaml) }}
 {{- end }}

--- a/charts/environment/templates/chart_apps.yaml
+++ b/charts/environment/templates/chart_apps.yaml
@@ -4,14 +4,6 @@
 {{- $chart_path := ternary $.Values.repository.paths.app_charts $.Values.repository.paths.charts (eq $chart_app_obj.app true) }}
 {{- $env_path := ternary $.Values.repository.paths.env_from_app_charts $.Values.repository.paths.env_from_charts (eq $chart_app_obj.app true) }}
 {{- $globals_path := ternary $.Values.repository.paths.globals_from_app_charts $.Values.repository.paths.globals_from_charts (eq $chart_app_obj.app true) }}
-{{- $chart_override := "" }}
-{{- with $chart_app_obj.chart }}
-{{- $chart_override = tpl . $ }}
-{{- end }}
-{{- $values_object := dict }}
-{{- with $chart_app_obj.valuesObject }}
-{{- $values_object = mergeOverwrite $values_object (tpl (toYaml .) $ | fromYaml) }}
-{{- end }}
 {{- if $chart_app_obj.enabled -}}
 ---
 apiVersion: argoproj.io/v1alpha1
@@ -68,9 +60,9 @@ spec:
       parameters:
     {{- tpl (toYaml .) $ | nindent 8 }}
     {{- end }}
-    {{- with $values_object }}
+    {{- with $chart_app_obj.valuesObject }}
       valuesObject:
-    {{- toYaml . | nindent 8 }}
+    {{- tpl (toYaml .) $ | nindent 8 }}
     {{- end }}
     {{- if $chart_app_obj.values }}
       values: {{ tpl (toYaml $chart_app_obj.values) $ | nindent 8 }}
@@ -109,9 +101,9 @@ spec:
       parameters:
     {{- tpl (toYaml .) $ | nindent 8 }}
     {{- end }}
-    {{- with $values_object }}
+    {{- with $chart_app_obj.valuesObject }}
       valuesObject:
-    {{- toYaml . | nindent 8 }}
+    {{- tpl (toYaml .) $ | nindent 8 }}
     {{- end }}
     {{- if $chart_app_obj.values }}
       values: {{ tpl (toYaml $chart_app_obj.values) $ | nindent 8 }}

--- a/charts/environment/values.yaml
+++ b/charts/environment/values.yaml
@@ -82,11 +82,25 @@ chart_apps:
         listenerTemplate:
           metadata:
             annotations:
-              argocd.argoproj.io/tracking-id: gha-runner-{{ .Values.global.env.name }}:argoproj.io/Application:argocd/gha-runner-{{ .Values.global.env.name }}
+              argocd.argoproj.io/tracking-id: gha-runner-{{ .Values.global.env.name }}:actions.github.com/Pod:gha-operator/gha-runner-{{ .Values.global.env.name }}
         resourceMeta:
           autoscalingListener:
             annotations:
-              argocd.argoproj.io/tracking-id: gha-runner-{{ .Values.global.env.name }}:argoproj.io/Application:argocd/gha-runner-{{ .Values.global.env.name }}
+              argocd.argoproj.io/tracking-id: gha-runner-{{ .Values.global.env.name }}:actions.github.com/AutoscalingListener:gha-operator/gha-runner-{{ .Values.global.env.name }}
+  gha-runner-app:
+    enabled: false
+    chart: argocd/charts/infra/charts/gha-runner
+    values: |
+      global: {{ .Values.global | toYaml | nindent 4 }}
+      gha-runner:
+        listenerTemplate:
+          metadata:
+            annotations:
+              argocd.argoproj.io/tracking-id: gha-runner-app-{{ .Values.global.env.name }}:actions.github.com/Pod:gha-operator/gha-runner-app-{{ .Values.global.env.name }}
+        resourceMeta:
+          autoscalingListener:
+            annotations:
+              argocd.argoproj.io/tracking-id: gha-runner-app-{{ .Values.global.env.name }}:actions.github.com/AutoscalingListener:gha-operator/gha-runner-app-{{ .Values.global.env.name }}
   gha-operator:
     enabled: false
     values: |
@@ -224,5 +238,10 @@ chart_apps:
 
   gl-runner:
     enabled: false
+    values: |
+      global: {{ .Values.global | toYaml | nindent 4 }}
+  gl-runner-app:
+    enabled: false
+    chart: argocd/charts/infra/charts/gl-runner
     values: |
       global: {{ .Values.global | toYaml | nindent 4 }}

--- a/charts/environment/values.yaml
+++ b/charts/environment/values.yaml
@@ -248,3 +248,7 @@ chart_apps:
     chart: argocd/charts/infra/charts/gl-runner
     values: |
       global: {{ .Values.global | toYaml | nindent 4 }}
+      gl-runner:
+        runners:
+          secret: "runner-app"
+          serviceAccount: "runner-app"

--- a/charts/environment/values.yaml
+++ b/charts/environment/values.yaml
@@ -82,7 +82,7 @@ chart_apps:
         listenerTemplate:
           metadata:
             annotations:
-              argocd.argoproj.io/tracking-id: gha-runner-{{ .Values.global.env.name }}:actions.github.com/Pod:gha-runnerr/gha-runner-{{ .Values.global.env.name }}
+              argocd.argoproj.io/tracking-id: gha-runner-{{ .Values.global.env.name }}:actions.github.com/Pod:gha-runner/gha-runner-{{ .Values.global.env.name }}
         resourceMeta:
           autoscalingListener:
             annotations:

--- a/charts/environment/values.yaml
+++ b/charts/environment/values.yaml
@@ -78,6 +78,18 @@ chart_apps:
     enabled: false
     values: |
       global: {{ .Values.global | toYaml | nindent 4 }}
+      gha-runner:
+        listenerTemplate:
+          metadata:
+            annotations:
+              argocd.argoproj.io/tracking-id: gha-runner-{{ .Values.global.env.name }}:argoproj.io/Application:argocd/gha-runner-{{ .Values.global.env.name }}
+        resourceMeta:
+          autoscalingListener:
+            annotations:
+              argocd.argoproj.io/tracking-id: gha-runner-{{ .Values.global.env.name }}:argoproj.io/Application:argocd/gha-runner-{{ .Values.global.env.name }}
+          autoscalingRunnerSet:
+            annotations:
+              argocd.argoproj.io/tracking-id: gha-runner-{{ .Values.global.env.name }}:actions.github.com/AutoscalingRunnerSet:gha-runner/gha-runner-{{ .Values.global.env.name }}
   gha-operator:
     enabled: false
     values: |

--- a/charts/environment/values.yaml
+++ b/charts/environment/values.yaml
@@ -89,7 +89,7 @@ chart_apps:
               argocd.argoproj.io/tracking-id: gha-runner-{{ .Values.global.env.name }}:actions.github.com/AutoscalingListener:gha-runner/gha-runner-{{ .Values.global.env.name }}
   gha-runner-app:
     enabled: false
-    chart: argocd/charts/infra/charts/gha-runner
+    chart: "{{ .Values.repository.paths.charts }}/gha-runner"
     values: |
       global: {{ .Values.global | toYaml | nindent 4 }}
       workflowConfigMap:
@@ -245,7 +245,7 @@ chart_apps:
       global: {{ .Values.global | toYaml | nindent 4 }}
   gl-runner-app:
     enabled: false
-    chart: argocd/charts/infra/charts/gl-runner
+    chart: "{{ .Values.repository.paths.charts }}/gl-runner"
     values: |
       global: {{ .Values.global | toYaml | nindent 4 }}
       gl-runner:

--- a/charts/environment/values.yaml
+++ b/charts/environment/values.yaml
@@ -93,6 +93,9 @@ chart_apps:
     values: |
       global: {{ .Values.global | toYaml | nindent 4 }}
       gha-runner:
+        workflowConfigMap:
+          spec:
+            serviceAccountName: runner-app
         listenerTemplate:
           metadata:
             annotations:

--- a/charts/environment/values.yaml
+++ b/charts/environment/values.yaml
@@ -82,11 +82,11 @@ chart_apps:
         listenerTemplate:
           metadata:
             annotations:
-              argocd.argoproj.io/tracking-id: gha-runner-{{ .Values.global.env.name }}:actions.github.com/Pod:gha-operator/gha-runner-{{ .Values.global.env.name }}
+              argocd.argoproj.io/tracking-id: gha-runner-{{ .Values.global.env.name }}:actions.github.com/Pod:gha-runnerr/gha-runner-{{ .Values.global.env.name }}
         resourceMeta:
           autoscalingListener:
             annotations:
-              argocd.argoproj.io/tracking-id: gha-runner-{{ .Values.global.env.name }}:actions.github.com/AutoscalingListener:gha-operator/gha-runner-{{ .Values.global.env.name }}
+              argocd.argoproj.io/tracking-id: gha-runner-{{ .Values.global.env.name }}:actions.github.com/AutoscalingListener:gha-runner/gha-runner-{{ .Values.global.env.name }}
   gha-runner-app:
     enabled: false
     chart: argocd/charts/infra/charts/gha-runner
@@ -99,11 +99,11 @@ chart_apps:
         listenerTemplate:
           metadata:
             annotations:
-              argocd.argoproj.io/tracking-id: gha-runner-app-{{ .Values.global.env.name }}:actions.github.com/Pod:gha-operator/gha-runner-app-{{ .Values.global.env.name }}
+              argocd.argoproj.io/tracking-id: gha-runner-app-{{ .Values.global.env.name }}:actions.github.com/Pod:gha-runner-app/gha-runner-app-{{ .Values.global.env.name }}
         resourceMeta:
           autoscalingListener:
             annotations:
-              argocd.argoproj.io/tracking-id: gha-runner-app-{{ .Values.global.env.name }}:actions.github.com/AutoscalingListener:gha-operator/gha-runner-app-{{ .Values.global.env.name }}
+              argocd.argoproj.io/tracking-id: gha-runner-app-{{ .Values.global.env.name }}:actions.github.com/AutoscalingListener:gha-runner-app/gha-runner-app-{{ .Values.global.env.name }}
   gha-operator:
     enabled: false
     values: |

--- a/charts/environment/values.yaml
+++ b/charts/environment/values.yaml
@@ -87,9 +87,6 @@ chart_apps:
           autoscalingListener:
             annotations:
               argocd.argoproj.io/tracking-id: gha-runner-{{ .Values.global.env.name }}:argoproj.io/Application:argocd/gha-runner-{{ .Values.global.env.name }}
-          autoscalingRunnerSet:
-            annotations:
-              argocd.argoproj.io/tracking-id: gha-runner-{{ .Values.global.env.name }}:actions.github.com/AutoscalingRunnerSet:gha-runner/gha-runner-{{ .Values.global.env.name }}
   gha-operator:
     enabled: false
     values: |

--- a/charts/environment/values.yaml
+++ b/charts/environment/values.yaml
@@ -92,10 +92,10 @@ chart_apps:
     chart: argocd/charts/infra/charts/gha-runner
     values: |
       global: {{ .Values.global | toYaml | nindent 4 }}
+      workflowConfigMap:
+        spec:
+          serviceAccountName: runner-app
       gha-runner:
-        workflowConfigMap:
-          spec:
-            serviceAccountName: runner-app
         listenerTemplate:
           metadata:
             annotations:

--- a/charts/gha-operator/Chart.lock
+++ b/charts/gha-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: gha-runner-scale-set-controller
   repository: oci://ghcr.io/actions/actions-runner-controller-charts
-  version: 0.13.0
-digest: sha256:f0105d7286725787c1faaea0a2a1021a850759299cb6e53bfd831617d8f20db0
-generated: "2026-02-20T10:59:29.228190234Z"
+  version: 0.14.2
+digest: sha256:11f7310c495946111886f8337173b41f7c67f5bd012dc025872f7e271df027b1
+generated: "2026-06-12T10:05:24.080846574Z"

--- a/charts/gha-operator/Chart.yaml
+++ b/charts/gha-operator/Chart.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 dependencies:
   #https://github.com/actions/actions-runner-controller/tree/master/charts/gha-runner-scale-set-controller
   - name: gha-runner-scale-set-controller
-    version: 0.13.0
+    version: 0.14.2
     repository: oci://ghcr.io/actions/actions-runner-controller-charts
     alias: gha-operator
     condition: gha-operator.enabled

--- a/charts/gha-runner/Chart.lock
+++ b/charts/gha-runner/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: gha-runner-scale-set
   repository: oci://ghcr.io/actions/actions-runner-controller-charts
-  version: 0.13.0
-digest: sha256:87f037ca67a98ef68ed3d21e33a61bfdc1b558213ab7062ffd287ea9e0a4272a
-generated: "2026-02-20T10:59:48.359841881Z"
+  version: 0.14.2
+digest: sha256:f01203cc00fc914943ae4fa2b550a9fddd3b2c7675941dacace9b191afa324eb
+generated: "2026-06-12T10:05:24.132860137Z"

--- a/charts/gha-runner/Chart.yaml
+++ b/charts/gha-runner/Chart.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 dependencies:
   #https://github.com/actions/actions-runner-controller/tree/master/charts/gha-runner-scale-set
   - name: gha-runner-scale-set
-    version: 0.13.0
+    version: 0.14.2
     repository: oci://ghcr.io/actions/actions-runner-controller-charts
     alias: gha-runner
     condition: gha-runner.enabled

--- a/charts/gha-runner/templates/workflow-pod.yaml
+++ b/charts/gha-runner/templates/workflow-pod.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.workflowConfigMap.enabled -}}
+{{- if .Values.gha-runner.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/gha-runner/templates/workflow-pod.yaml
+++ b/charts/gha-runner/templates/workflow-pod.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gha-runner.enabled -}}
+{{- if (index .Values "gha-runner").enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/gha-runner/values.yaml
+++ b/charts/gha-runner/values.yaml
@@ -1,5 +1,6 @@
 gha-runner:
   enabled: false
+  githubConfigSecret: github
   kubernetesModeServiceAccount:
   controllerServiceAccount:
     namespace: gha-operator

--- a/charts/gha-runner/values.yaml
+++ b/charts/gha-runner/values.yaml
@@ -72,8 +72,8 @@ workflowConfigMap:
             cpu: '1'
             memory: 4Gi
     initContainers:
-      - name: "$fs-init"
+      - name: "fs-init"
         resources:
-          request:
+          requests:
             cpu: 10m
             memory: 5Mi

--- a/charts/gha-runner/values.yaml
+++ b/charts/gha-runner/values.yaml
@@ -1,6 +1,6 @@
 gha-runner:
   enabled: false
-  runnerScaleSetName: "infra-runner"
+  #runnerScaleSetName: ""
   kubernetesModeServiceAccount:
   controllerServiceAccount:
     namespace: gha-operator

--- a/charts/gha-runner/values.yaml
+++ b/charts/gha-runner/values.yaml
@@ -6,7 +6,13 @@ gha-runner:
     namespace: gha-operator
     name: "gha-operator"
   containerMode:
-    type: "kubernetes-novolume"
+    #type: "kubernetes-novolume"
+    type: "kubernetes"
+    kubernetesModeWorkVolumeClaim:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 2Gi
   listenerTemplate:
     spec:
       containers:
@@ -37,6 +43,15 @@ gha-runner:
           env:
             - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
               value: "false"
+            - name: ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE
+              value: /home/runner/templates/workflow-pod.yaml
+          volumeMounts:
+            - mountPath: /home/runner/templates
+              name: templates
+      volumes:
+        - name: templates
+          configMap:
+            name: workflow-pod
 workflowConfigMap:
   enabled: false
   name: workflow-pod

--- a/charts/gha-runner/values.yaml
+++ b/charts/gha-runner/values.yaml
@@ -6,12 +6,7 @@ gha-runner:
     namespace: gha-operator
     name: "gha-operator"
   containerMode:
-    type: "kubernetes"
-    kubernetesModeWorkVolumeClaim:
-      accessModes: ["ReadWriteOnce"]
-      resources:
-        requests:
-          storage: 2Gi
+    type: "kubernetes-novolume"
   listenerTemplate:
     spec:
       containers:
@@ -38,23 +33,15 @@ gha-runner:
         - name: runner
           image: ghcr.io/actions/actions-runner:latest
           command: ["/home/runner/run.sh"]
+          resources: {}
           env:
-            - name: ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE
-              value: /home/runner/templates/workflow-pod.yaml
             - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
               value: "false"
-          volumeMounts:
-            - mountPath: /home/runner/templates
-              name: templates
-      volumes:
-        - name: templates
-          configMap:
-            name: workflow-pod
 workflowConfigMap:
   enabled: false
   name: workflow-pod
   metaAnnotations:
-    argocd.argoproj.io/tracking-id: "{{ .Release.Name }}:/Pod:{{ .Release.Namespace }}/workflow-pod" 
+    argocd.argoproj.io/tracking-id: "{{ .Release.Name }}:/Pod:{{ .Release.Namespace }}/workflow-pod"
   spec:
     securityContext:
       fsGroup: 1001

--- a/charts/gha-runner/values.yaml
+++ b/charts/gha-runner/values.yaml
@@ -44,7 +44,7 @@ gha-runner:
               memory: 240Mi
           env:
             - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
-              value: "false"
+              value: 'false'
             - name: ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE
               value: /home/runner/templates/workflow-pod.yaml
           volumeMounts:
@@ -66,5 +66,5 @@ workflowConfigMap:
       - name: "$job"
         resources:
           requests:
-            cpu: "1"
-            memory: "4Gi"
+            cpu: '1'
+            memory: 4Gi

--- a/charts/gha-runner/values.yaml
+++ b/charts/gha-runner/values.yaml
@@ -7,11 +7,6 @@ gha-runner:
     name: "gha-operator"
   containerMode:
     type: "kubernetes-novolume"
-    kubernetesModeWorkVolumeClaim:
-      accessModes: ["ReadWriteOnce"]
-      resources:
-        requests:
-          storage: 2Gi
   listenerTemplate:
     spec:
       containers:

--- a/charts/gha-runner/values.yaml
+++ b/charts/gha-runner/values.yaml
@@ -42,6 +42,9 @@ gha-runner:
             requests:
               cpu: 30m
               memory: 240Mi
+            limits:
+              cpu: 300m
+              memory: 500Mi
           env:
             - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
               value: 'false'
@@ -68,3 +71,9 @@ workflowConfigMap:
           requests:
             cpu: '1'
             memory: 4Gi
+    initContainers:
+      - name: "$fs-init"
+        resources:
+          request:
+            cpu: 10m
+            memory: 5Mi

--- a/charts/gha-runner/values.yaml
+++ b/charts/gha-runner/values.yaml
@@ -63,7 +63,7 @@ workflowConfigMap:
     securityContext:
       fsGroup: 1001
     containers:
-      - name: job
+      - name: "$job"
         resources:
           requests:
             cpu: "1"

--- a/charts/gha-runner/values.yaml
+++ b/charts/gha-runner/values.yaml
@@ -1,6 +1,5 @@
 gha-runner:
   enabled: false
-  #runnerScaleSetName: ""
   kubernetesModeServiceAccount:
   controllerServiceAccount:
     namespace: gha-operator

--- a/charts/gha-runner/values.yaml
+++ b/charts/gha-runner/values.yaml
@@ -40,8 +40,8 @@ gha-runner:
           command: ["/home/runner/run.sh"]
           resources:
             requests:
-              cpu: '1'
-              memory: 4Gi
+              cpu: 30m
+              memory: 240Mi
           env:
             - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
               value: "false"

--- a/charts/gha-runner/values.yaml
+++ b/charts/gha-runner/values.yaml
@@ -38,7 +38,10 @@ gha-runner:
         - name: runner
           image: ghcr.io/actions/actions-runner:latest
           command: ["/home/runner/run.sh"]
-          resources: {}
+          resources:
+            requests:
+              cpu: '1'
+              memory: 4Gi
           env:
             - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
               value: "false"

--- a/charts/gha-runner/values.yaml
+++ b/charts/gha-runner/values.yaml
@@ -62,3 +62,9 @@ workflowConfigMap:
   spec:
     securityContext:
       fsGroup: 1001
+    containers:
+      - name: job
+        resources:
+          requests:
+            cpu: "1"
+            memory: "4Gi"

--- a/charts/gha-runner/values.yaml
+++ b/charts/gha-runner/values.yaml
@@ -6,8 +6,7 @@ gha-runner:
     namespace: gha-operator
     name: "gha-operator"
   containerMode:
-    #type: "kubernetes-novolume"
-    type: "kubernetes"
+    type: "kubernetes-novolume"
     kubernetesModeWorkVolumeClaim:
       accessModes: ["ReadWriteOnce"]
       resources:

--- a/charts/gha-runner/values.yaml
+++ b/charts/gha-runner/values.yaml
@@ -71,9 +71,3 @@ workflowConfigMap:
           requests:
             cpu: '1'
             memory: 4Gi
-    initContainers:
-      - name: "fs-init"
-        resources:
-          requests:
-            cpu: 10m
-            memory: 5Mi

--- a/charts/gha-runner/values.yaml
+++ b/charts/gha-runner/values.yaml
@@ -53,11 +53,11 @@ gha-runner:
           configMap:
             name: workflow-pod
 workflowConfigMap:
-  enabled: false
   name: workflow-pod
   metaAnnotations:
     argocd.argoproj.io/tracking-id: "{{ .Release.Name }}:/Pod:{{ .Release.Namespace }}/workflow-pod"
   spec:
+    serviceAccountName: runner
     securityContext:
       fsGroup: 1001
     containers:

--- a/crds/gha-operator/0.14.2.actions.github.com_autoscalinglisteners.yaml
+++ b/crds/gha-operator/0.14.2.actions.github.com_autoscalinglisteners.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: autoscalinglisteners.actions.github.com
 spec:
   group: actions.github.com
@@ -56,6 +56,19 @@ spec:
               autoscalingRunnerSetNamespace:
                 description: Required
                 type: string
+              configSecretMetadata:
+                description: ResourceMeta carries metadata common to all internal
+                  resources
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
               ephemeralRunnerSetName:
                 description: Required
                 type: string
@@ -196,9 +209,48 @@ spec:
                       type: string
                     type: array
                 type: object
+              roleBindingMetadata:
+                description: ResourceMeta carries metadata common to all internal
+                  resources
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              roleMetadata:
+                description: ResourceMeta carries metadata common to all internal
+                  resources
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
               runnerScaleSetId:
                 description: Required
                 type: integer
+              serviceAccountMetadata:
+                description: ResourceMeta carries metadata common to all internal
+                  resources
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
               template:
                 description: PodTemplateSpec describes the data a pod should have
                   when created from a template
@@ -2049,7 +2101,9 @@ spec:
                                   type: integer
                               type: object
                             resizePolicy:
-                              description: Resources resize policy for the container.
+                              description: |-
+                                Resources resize policy for the container.
+                                This field cannot be set on ephemeral containers.
                               items:
                                 description: ContainerResizePolicy represents resource
                                   resize policy for the container.
@@ -5272,7 +5326,9 @@ spec:
                                   type: integer
                               type: object
                             resizePolicy:
-                              description: Resources resize policy for the container.
+                              description: |-
+                                Resources resize policy for the container.
+                                This field cannot be set on ephemeral containers.
                               items:
                                 description: ContainerResizePolicy represents resource
                                   resize policy for the container.
@@ -6059,8 +6115,8 @@ spec:
                           will be made available to those containers which consume them
                           by name.
 
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
+                          This is a stable field but requires that the
+                          DynamicResourceAllocation feature gate is enabled.
 
                           This field is immutable.
                         items:
@@ -6519,9 +6575,10 @@ spec:
                             operator:
                               description: |-
                                 Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                 Exists is equivalent to wildcard for value, so that a pod can
                                 tolerate all taints of a particular category.
+                                Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                               type: string
                             tolerationSeconds:
                               description: |-
@@ -7332,7 +7389,7 @@ spec:
                                         resources:
                                           description: |-
                                             resources represents the minimum resources the volume should have.
-                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                            Users are allowed to specify resource requirements
                                             that are lower than previous value but must still be higher than capacity recorded in the
                                             status field of the claim.
                                             More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -8218,6 +8275,24 @@ spec:
                                             description: Kubelet's generated CSRs
                                               will be addressed to this signer.
                                             type: string
+                                          userAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              userAnnotations allow pod authors to pass additional information to
+                                              the signer implementation.  Kubernetes does not restrict or validate this
+                                              metadata in any way.
+
+                                              These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                              the PodCertificateRequest objects that Kubelet creates.
+
+                                              Entries are subject to the same validation as object metadata annotations,
+                                              with the addition that all keys must be domain-prefixed. No restrictions
+                                              are placed on values, except an overall size limitation on the entire field.
+
+                                              Signers should document the keys and values they support. Signers should
+                                              deny requests that contain keys they do not recognize.
+                                            type: object
                                         required:
                                         - keyType
                                         - signerName
@@ -8643,6 +8718,42 @@ spec:
                         x-kubernetes-list-map-keys:
                         - name
                         x-kubernetes-list-type: map
+                      workloadRef:
+                        description: |-
+                          WorkloadRef provides a reference to the Workload object that this Pod belongs to.
+                          This field is used by the scheduler to identify the PodGroup and apply the
+                          correct group scheduling policies. The Workload object referenced
+                          by this field may not exist at the time the Pod is created.
+                          This field is immutable, but a Workload object with the same name
+                          may be recreated with different policies. Doing this during pod scheduling
+                          may result in the placement not conforming to the expected policies.
+                        properties:
+                          name:
+                            description: |-
+                              Name defines the name of the Workload object this Pod belongs to.
+                              Workload must be in the same namespace as the Pod.
+                              If it doesn't match any existing Workload, the Pod will remain unschedulable
+                              until a Workload object is created and observed by the kube-scheduler.
+                              It must be a DNS subdomain.
+                            type: string
+                          podGroup:
+                            description: |-
+                              PodGroup is the name of the PodGroup within the Workload that this Pod
+                              belongs to. If it doesn't match any existing PodGroup within the Workload,
+                              the Pod will remain unschedulable until the Workload object is recreated
+                              and observed by the kube-scheduler. It must be a DNS label.
+                            type: string
+                          podGroupReplicaKey:
+                            description: |-
+                              PodGroupReplicaKey specifies the replica key of the PodGroup to which this
+                              Pod belongs. It is used to distinguish pods belonging to different replicas
+                              of the same pod group. The pod group policy is applied separately to each replica.
+                              When set, it must be a DNS label.
+                            type: string
+                        required:
+                        - name
+                        - podGroup
+                        type: object
                     required:
                     - containers
                     type: object

--- a/crds/gha-operator/0.14.2.actions.github.com_autoscalingrunnersets.yaml
+++ b/crds/gha-operator/0.14.2.actions.github.com_autoscalingrunnersets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: autoscalingrunnersets.actions.github.com
 spec:
   group: actions.github.com
@@ -64,6 +64,54 @@ spec:
             spec:
               description: AutoscalingRunnerSetSpec defines the desired state of AutoscalingRunnerSet
               properties:
+                autoscalingListener:
+                  description: ResourceMeta carries metadata common to all internal resources
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                ephemeralRunnerConfigSecretMetadata:
+                  description: ResourceMeta carries metadata common to all internal resources
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                ephemeralRunnerMetadata:
+                  description: ResourceMeta carries metadata common to all internal resources
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                ephemeralRunnerSetMetadata:
+                  description: ResourceMeta carries metadata common to all internal resources
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
                 githubConfigSecret:
                   description: Required
                   type: string
@@ -97,6 +145,18 @@ spec:
                             - key
                           type: object
                           x-kubernetes-map-type: atomic
+                      type: object
+                  type: object
+                listenerConfigSecretMetadata:
+                  description: ResourceMeta carries metadata common to all internal resources
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
                       type: object
                   type: object
                 listenerMetrics:
@@ -141,6 +201,42 @@ spec:
                         required:
                           - labels
                         type: object
+                      type: object
+                  type: object
+                listenerRoleBindingMetadata:
+                  description: ResourceMeta carries metadata common to all internal resources
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                listenerRoleMetadata:
+                  description: ResourceMeta carries metadata common to all internal resources
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                listenerServiceAccountMetadata:
+                  description: ResourceMeta carries metadata common to all internal resources
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
                       type: object
                   type: object
                 listenerTemplate:
@@ -1890,7 +1986,9 @@ spec:
                                     type: integer
                                 type: object
                               resizePolicy:
-                                description: Resources resize policy for the container.
+                                description: |-
+                                  Resources resize policy for the container.
+                                  This field cannot be set on ephemeral containers.
                                 items:
                                   description: ContainerResizePolicy represents resource resize policy for the container.
                                   properties:
@@ -4963,7 +5061,9 @@ spec:
                                     type: integer
                                 type: object
                               resizePolicy:
-                                description: Resources resize policy for the container.
+                                description: |-
+                                  Resources resize policy for the container.
+                                  This field cannot be set on ephemeral containers.
                                 items:
                                   description: ContainerResizePolicy represents resource resize policy for the container.
                                   properties:
@@ -5724,8 +5824,8 @@ spec:
                             will be made available to those containers which consume them
                             by name.
 
-                            This is an alpha field and requires enabling the
-                            DynamicResourceAllocation feature gate.
+                            This is a stable field but requires that the
+                            DynamicResourceAllocation feature gate is enabled.
 
                             This field is immutable.
                           items:
@@ -6177,9 +6277,10 @@ spec:
                               operator:
                                 description: |-
                                   Operator represents a key's relationship to the value.
-                                  Valid operators are Exists and Equal. Defaults to Equal.
+                                  Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                   Exists is equivalent to wildcard for value, so that a pod can
                                   tolerate all taints of a particular category.
+                                  Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                 type: string
                               tolerationSeconds:
                                 description: |-
@@ -6951,7 +7052,7 @@ spec:
                                           resources:
                                             description: |-
                                               resources represents the minimum resources the volume should have.
-                                              If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                              Users are allowed to specify resource requirements
                                               that are lower than previous value but must still be higher than capacity recorded in the
                                               status field of the claim.
                                               More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -7786,6 +7887,24 @@ spec:
                                             signerName:
                                               description: Kubelet's generated CSRs will be addressed to this signer.
                                               type: string
+                                            userAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                userAnnotations allow pod authors to pass additional information to
+                                                the signer implementation.  Kubernetes does not restrict or validate this
+                                                metadata in any way.
+
+                                                These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                                the PodCertificateRequest objects that Kubelet creates.
+
+                                                Entries are subject to the same validation as object metadata annotations,
+                                                with the addition that all keys must be domain-prefixed. No restrictions
+                                                are placed on values, except an overall size limitation on the entire field.
+
+                                                Signers should document the keys and values they support. Signers should
+                                                deny requests that contain keys they do not recognize.
+                                              type: object
                                           required:
                                             - keyType
                                             - signerName
@@ -8195,6 +8314,42 @@ spec:
                           x-kubernetes-list-map-keys:
                             - name
                           x-kubernetes-list-type: map
+                        workloadRef:
+                          description: |-
+                            WorkloadRef provides a reference to the Workload object that this Pod belongs to.
+                            This field is used by the scheduler to identify the PodGroup and apply the
+                            correct group scheduling policies. The Workload object referenced
+                            by this field may not exist at the time the Pod is created.
+                            This field is immutable, but a Workload object with the same name
+                            may be recreated with different policies. Doing this during pod scheduling
+                            may result in the placement not conforming to the expected policies.
+                          properties:
+                            name:
+                              description: |-
+                                Name defines the name of the Workload object this Pod belongs to.
+                                Workload must be in the same namespace as the Pod.
+                                If it doesn't match any existing Workload, the Pod will remain unschedulable
+                                until a Workload object is created and observed by the kube-scheduler.
+                                It must be a DNS subdomain.
+                              type: string
+                            podGroup:
+                              description: |-
+                                PodGroup is the name of the PodGroup within the Workload that this Pod
+                                belongs to. If it doesn't match any existing PodGroup within the Workload,
+                                the Pod will remain unschedulable until the Workload object is recreated
+                                and observed by the kube-scheduler. It must be a DNS label.
+                              type: string
+                            podGroupReplicaKey:
+                              description: |-
+                                PodGroupReplicaKey specifies the replica key of the PodGroup to which this
+                                Pod belongs. It is used to distinguish pods belonging to different replicas
+                                of the same pod group. The pod group policy is applied separately to each replica.
+                                When set, it must be a DNS label.
+                              type: string
+                          required:
+                            - name
+                            - podGroup
+                          type: object
                       required:
                         - containers
                       type: object
@@ -8230,6 +8385,10 @@ spec:
                   type: object
                 runnerGroup:
                   type: string
+                runnerScaleSetLabels:
+                  items:
+                    type: string
+                  type: array
                 runnerScaleSetName:
                   type: string
                 template:
@@ -9979,7 +10138,9 @@ spec:
                                     type: integer
                                 type: object
                               resizePolicy:
-                                description: Resources resize policy for the container.
+                                description: |-
+                                  Resources resize policy for the container.
+                                  This field cannot be set on ephemeral containers.
                                 items:
                                   description: ContainerResizePolicy represents resource resize policy for the container.
                                   properties:
@@ -13046,7 +13207,9 @@ spec:
                                     type: integer
                                 type: object
                               resizePolicy:
-                                description: Resources resize policy for the container.
+                                description: |-
+                                  Resources resize policy for the container.
+                                  This field cannot be set on ephemeral containers.
                                 items:
                                   description: ContainerResizePolicy represents resource resize policy for the container.
                                   properties:
@@ -13804,8 +13967,8 @@ spec:
                             will be made available to those containers which consume them
                             by name.
 
-                            This is an alpha field and requires enabling the
-                            DynamicResourceAllocation feature gate.
+                            This is a stable field but requires that the
+                            DynamicResourceAllocation feature gate is enabled.
 
                             This field is immutable.
                           items:
@@ -14254,9 +14417,10 @@ spec:
                               operator:
                                 description: |-
                                   Operator represents a key's relationship to the value.
-                                  Valid operators are Exists and Equal. Defaults to Equal.
+                                  Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                   Exists is equivalent to wildcard for value, so that a pod can
                                   tolerate all taints of a particular category.
+                                  Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                 type: string
                               tolerationSeconds:
                                 description: |-
@@ -15028,7 +15192,7 @@ spec:
                                           resources:
                                             description: |-
                                               resources represents the minimum resources the volume should have.
-                                              If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                              Users are allowed to specify resource requirements
                                               that are lower than previous value but must still be higher than capacity recorded in the
                                               status field of the claim.
                                               More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -15863,6 +16027,24 @@ spec:
                                             signerName:
                                               description: Kubelet's generated CSRs will be addressed to this signer.
                                               type: string
+                                            userAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                userAnnotations allow pod authors to pass additional information to
+                                                the signer implementation.  Kubernetes does not restrict or validate this
+                                                metadata in any way.
+
+                                                These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                                the PodCertificateRequest objects that Kubelet creates.
+
+                                                Entries are subject to the same validation as object metadata annotations,
+                                                with the addition that all keys must be domain-prefixed. No restrictions
+                                                are placed on values, except an overall size limitation on the entire field.
+
+                                                Signers should document the keys and values they support. Signers should
+                                                deny requests that contain keys they do not recognize.
+                                              type: object
                                           required:
                                             - keyType
                                             - signerName
@@ -16272,6 +16454,42 @@ spec:
                           x-kubernetes-list-map-keys:
                             - name
                           x-kubernetes-list-type: map
+                        workloadRef:
+                          description: |-
+                            WorkloadRef provides a reference to the Workload object that this Pod belongs to.
+                            This field is used by the scheduler to identify the PodGroup and apply the
+                            correct group scheduling policies. The Workload object referenced
+                            by this field may not exist at the time the Pod is created.
+                            This field is immutable, but a Workload object with the same name
+                            may be recreated with different policies. Doing this during pod scheduling
+                            may result in the placement not conforming to the expected policies.
+                          properties:
+                            name:
+                              description: |-
+                                Name defines the name of the Workload object this Pod belongs to.
+                                Workload must be in the same namespace as the Pod.
+                                If it doesn't match any existing Workload, the Pod will remain unschedulable
+                                until a Workload object is created and observed by the kube-scheduler.
+                                It must be a DNS subdomain.
+                              type: string
+                            podGroup:
+                              description: |-
+                                PodGroup is the name of the PodGroup within the Workload that this Pod
+                                belongs to. If it doesn't match any existing PodGroup within the Workload,
+                                the Pod will remain unschedulable until the Workload object is recreated
+                                and observed by the kube-scheduler. It must be a DNS label.
+                              type: string
+                            podGroupReplicaKey:
+                              description: |-
+                                PodGroupReplicaKey specifies the replica key of the PodGroup to which this
+                                Pod belongs. It is used to distinguish pods belonging to different replicas
+                                of the same pod group. The pod group policy is applied separately to each replica.
+                                When set, it must be a DNS label.
+                              type: string
+                          required:
+                            - name
+                            - podGroup
+                          type: object
                       required:
                         - containers
                       type: object
@@ -16333,10 +16551,10 @@ spec:
                   type: integer
                 pendingEphemeralRunners:
                   type: integer
+                phase:
+                  type: string
                 runningEphemeralRunners:
                   type: integer
-                state:
-                  type: string
               type: object
           type: object
       served: true

--- a/crds/gha-operator/0.14.2.actions.github.com_ephemeralrunners.yaml
+++ b/crds/gha-operator/0.14.2.actions.github.com_ephemeralrunners.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: ephemeralrunners.actions.github.com
 spec:
   group: actions.github.com
@@ -70,6 +70,18 @@ spec:
             spec:
               description: EphemeralRunnerSpec defines the desired state of EphemeralRunner
               properties:
+                ephemeralRunnerConfigSecretMetadata:
+                  description: ResourceMeta carries metadata common to all internal resources
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
                 githubConfigSecret:
                   type: string
                 githubConfigUrl:
@@ -1874,7 +1886,9 @@ spec:
                                 type: integer
                             type: object
                           resizePolicy:
-                            description: Resources resize policy for the container.
+                            description: |-
+                              Resources resize policy for the container.
+                              This field cannot be set on ephemeral containers.
                             items:
                               description: ContainerResizePolicy represents resource resize policy for the container.
                               properties:
@@ -4941,7 +4955,9 @@ spec:
                                 type: integer
                             type: object
                           resizePolicy:
-                            description: Resources resize policy for the container.
+                            description: |-
+                              Resources resize policy for the container.
+                              This field cannot be set on ephemeral containers.
                             items:
                               description: ContainerResizePolicy represents resource resize policy for the container.
                               properties:
@@ -5699,8 +5715,8 @@ spec:
                         will be made available to those containers which consume them
                         by name.
 
-                        This is an alpha field and requires enabling the
-                        DynamicResourceAllocation feature gate.
+                        This is a stable field but requires that the
+                        DynamicResourceAllocation feature gate is enabled.
 
                         This field is immutable.
                       items:
@@ -6152,9 +6168,10 @@ spec:
                           operator:
                             description: |-
                               Operator represents a key's relationship to the value.
-                              Valid operators are Exists and Equal. Defaults to Equal.
+                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                               Exists is equivalent to wildcard for value, so that a pod can
                               tolerate all taints of a particular category.
+                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                             type: string
                           tolerationSeconds:
                             description: |-
@@ -6926,7 +6943,7 @@ spec:
                                       resources:
                                         description: |-
                                           resources represents the minimum resources the volume should have.
-                                          If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                          Users are allowed to specify resource requirements
                                           that are lower than previous value but must still be higher than capacity recorded in the
                                           status field of the claim.
                                           More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -7761,6 +7778,24 @@ spec:
                                         signerName:
                                           description: Kubelet's generated CSRs will be addressed to this signer.
                                           type: string
+                                        userAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            userAnnotations allow pod authors to pass additional information to
+                                            the signer implementation.  Kubernetes does not restrict or validate this
+                                            metadata in any way.
+
+                                            These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                            the PodCertificateRequest objects that Kubelet creates.
+
+                                            Entries are subject to the same validation as object metadata annotations,
+                                            with the addition that all keys must be domain-prefixed. No restrictions
+                                            are placed on values, except an overall size limitation on the entire field.
+
+                                            Signers should document the keys and values they support. Signers should
+                                            deny requests that contain keys they do not recognize.
+                                          type: object
                                       required:
                                         - keyType
                                         - signerName
@@ -8170,6 +8205,42 @@ spec:
                       x-kubernetes-list-map-keys:
                         - name
                       x-kubernetes-list-type: map
+                    workloadRef:
+                      description: |-
+                        WorkloadRef provides a reference to the Workload object that this Pod belongs to.
+                        This field is used by the scheduler to identify the PodGroup and apply the
+                        correct group scheduling policies. The Workload object referenced
+                        by this field may not exist at the time the Pod is created.
+                        This field is immutable, but a Workload object with the same name
+                        may be recreated with different policies. Doing this during pod scheduling
+                        may result in the placement not conforming to the expected policies.
+                      properties:
+                        name:
+                          description: |-
+                            Name defines the name of the Workload object this Pod belongs to.
+                            Workload must be in the same namespace as the Pod.
+                            If it doesn't match any existing Workload, the Pod will remain unschedulable
+                            until a Workload object is created and observed by the kube-scheduler.
+                            It must be a DNS subdomain.
+                          type: string
+                        podGroup:
+                          description: |-
+                            PodGroup is the name of the PodGroup within the Workload that this Pod
+                            belongs to. If it doesn't match any existing PodGroup within the Workload,
+                            the Pod will remain unschedulable until the Workload object is recreated
+                            and observed by the kube-scheduler. It must be a DNS label.
+                          type: string
+                        podGroupReplicaKey:
+                          description: |-
+                            PodGroupReplicaKey specifies the replica key of the PodGroup to which this
+                            Pod belongs. It is used to distinguish pods belonging to different replicas
+                            of the same pod group. The pod group policy is applied separately to each replica.
+                            When set, it must be a DNS label.
+                          type: string
+                      required:
+                        - name
+                        - podGroup
+                      type: object
                   required:
                     - containers
                   type: object

--- a/crds/gha-operator/0.14.2.actions.github.com_ephemeralrunnersets.yaml
+++ b/crds/gha-operator/0.14.2.actions.github.com_ephemeralrunnersets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: ephemeralrunnersets.actions.github.com
 spec:
   group: actions.github.com
@@ -58,9 +58,33 @@ spec:
             spec:
               description: EphemeralRunnerSetSpec defines the desired state of EphemeralRunnerSet
               properties:
+                ephemeralRunnerMetadata:
+                  description: ResourceMeta carries metadata common to all internal resources
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
                 ephemeralRunnerSpec:
                   description: EphemeralRunnerSpec is the spec of the ephemeral runner
                   properties:
+                    ephemeralRunnerConfigSecretMetadata:
+                      description: ResourceMeta carries metadata common to all internal resources
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
                     githubConfigSecret:
                       type: string
                     githubConfigUrl:
@@ -1865,7 +1889,9 @@ spec:
                                     type: integer
                                 type: object
                               resizePolicy:
-                                description: Resources resize policy for the container.
+                                description: |-
+                                  Resources resize policy for the container.
+                                  This field cannot be set on ephemeral containers.
                                 items:
                                   description: ContainerResizePolicy represents resource resize policy for the container.
                                   properties:
@@ -4932,7 +4958,9 @@ spec:
                                     type: integer
                                 type: object
                               resizePolicy:
-                                description: Resources resize policy for the container.
+                                description: |-
+                                  Resources resize policy for the container.
+                                  This field cannot be set on ephemeral containers.
                                 items:
                                   description: ContainerResizePolicy represents resource resize policy for the container.
                                   properties:
@@ -5690,8 +5718,8 @@ spec:
                             will be made available to those containers which consume them
                             by name.
 
-                            This is an alpha field and requires enabling the
-                            DynamicResourceAllocation feature gate.
+                            This is a stable field but requires that the
+                            DynamicResourceAllocation feature gate is enabled.
 
                             This field is immutable.
                           items:
@@ -6143,9 +6171,10 @@ spec:
                               operator:
                                 description: |-
                                   Operator represents a key's relationship to the value.
-                                  Valid operators are Exists and Equal. Defaults to Equal.
+                                  Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                   Exists is equivalent to wildcard for value, so that a pod can
                                   tolerate all taints of a particular category.
+                                  Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                 type: string
                               tolerationSeconds:
                                 description: |-
@@ -6917,7 +6946,7 @@ spec:
                                           resources:
                                             description: |-
                                               resources represents the minimum resources the volume should have.
-                                              If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                              Users are allowed to specify resource requirements
                                               that are lower than previous value but must still be higher than capacity recorded in the
                                               status field of the claim.
                                               More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -7752,6 +7781,24 @@ spec:
                                             signerName:
                                               description: Kubelet's generated CSRs will be addressed to this signer.
                                               type: string
+                                            userAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                userAnnotations allow pod authors to pass additional information to
+                                                the signer implementation.  Kubernetes does not restrict or validate this
+                                                metadata in any way.
+
+                                                These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                                the PodCertificateRequest objects that Kubelet creates.
+
+                                                Entries are subject to the same validation as object metadata annotations,
+                                                with the addition that all keys must be domain-prefixed. No restrictions
+                                                are placed on values, except an overall size limitation on the entire field.
+
+                                                Signers should document the keys and values they support. Signers should
+                                                deny requests that contain keys they do not recognize.
+                                              type: object
                                           required:
                                             - keyType
                                             - signerName
@@ -8161,6 +8208,42 @@ spec:
                           x-kubernetes-list-map-keys:
                             - name
                           x-kubernetes-list-type: map
+                        workloadRef:
+                          description: |-
+                            WorkloadRef provides a reference to the Workload object that this Pod belongs to.
+                            This field is used by the scheduler to identify the PodGroup and apply the
+                            correct group scheduling policies. The Workload object referenced
+                            by this field may not exist at the time the Pod is created.
+                            This field is immutable, but a Workload object with the same name
+                            may be recreated with different policies. Doing this during pod scheduling
+                            may result in the placement not conforming to the expected policies.
+                          properties:
+                            name:
+                              description: |-
+                                Name defines the name of the Workload object this Pod belongs to.
+                                Workload must be in the same namespace as the Pod.
+                                If it doesn't match any existing Workload, the Pod will remain unschedulable
+                                until a Workload object is created and observed by the kube-scheduler.
+                                It must be a DNS subdomain.
+                              type: string
+                            podGroup:
+                              description: |-
+                                PodGroup is the name of the PodGroup within the Workload that this Pod
+                                belongs to. If it doesn't match any existing PodGroup within the Workload,
+                                the Pod will remain unschedulable until the Workload object is recreated
+                                and observed by the kube-scheduler. It must be a DNS label.
+                              type: string
+                            podGroupReplicaKey:
+                              description: |-
+                                PodGroupReplicaKey specifies the replica key of the PodGroup to which this
+                                Pod belongs. It is used to distinguish pods belonging to different replicas
+                                of the same pod group. The pod group policy is applied separately to each replica.
+                                When set, it must be a DNS label.
+                              type: string
+                          required:
+                            - name
+                            - podGroup
+                          type: object
                       required:
                         - containers
                       type: object
@@ -8235,6 +8318,9 @@ spec:
                   type: integer
                 pendingEphemeralRunners:
                   type: integer
+                phase:
+                  description: EphemeralRunnerSetPhase is the phase of the ephemeral runner set resource
+                  type: string
                 runningEphemeralRunners:
                   type: integer
               required:

--- a/crds/gha-operator/update.sh
+++ b/crds/gha-operator/update.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-CRDS_VERSION="0.13.1"
+CRDS_VERSION="0.14.2"
 
 for file in `ls | grep -E 'yml|yaml'`
 do


### PR DESCRIPTION
New features:
* new app `gha-runner-app` and `gl-runner-app` in `charts/environment`

Enchancements:
* `gha-operator`:
  * `crds` update 0.13.1 -> 0.14.2
  * `chart` update 0.13.0 -> 0.14.2
* `gha-runner`:
  * `chart` update 0.13.0 -> 0.14.2
  * use `kubernetes-novolume` mode instead of `kubernetes`
  * delete `gha-runner storage`
  * set default `githubConfigSecret` = github
  * add `runner` pod `resources requests/limits`
  * add `workflow` pod `resources requests`
  * add default `serviceAccountName` for `workflow` pods
  * `workflowConfigMap` is enabled when `gha-runner.enabled` = true
* set default `secret and serviceAccount` for `gl-runner-app` runner pod

Fixes:
* `gha-runner/gha-runner-app`:
  * delete hardcode `runnerScaleSetName`, for correct names template
  * set default `argocd.argoproj.io/tracking-id` in `autoscalingListener` and `pod/listener` for correct tracking in argocd