### PR TITLE
fixes for the correct placement of pods on nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,8 +60,19 @@ Enhancements:
 * `argocd`:
   * move Redis `port` and `existingSecret` from `env` to `argocd` chart values
   * point external Redis host to the new Opstree Redis master service
+  * explicitly enable `gzip` Redis cache compression for consistent cache keys across Argo CD components
 * delete non-working `AbsentMetricCritical alerts`
-* `redis` image update 6.2.6 -> 8.6.1
+* `redis`:
+  * image update 6.2.6 -> 8.6.1
+  * add templated `topologySpreadConstraints` for Redis and Sentinel pods to distribute replicas across available nodes
+  * set `terminationGracePeriodSeconds` to 30 seconds for Redis and Sentinel pods
+* `rabbitmq-cluster`:
+  * add templated `topologySpreadConstraints` to distribute replicas across available nodes
+  * set `terminationGracePeriodSeconds` to 300 seconds instead of the operator's seven-day default
+* `loki`:
+  * add templated `topologySpreadConstraints` for read, write and backend pods
+  * disable default required pod anti-affinity so three replicas can be scheduled on two nodes
+  * explicitly set termination grace periods to 30 seconds for read pods and 300 seconds for write and backend pods
 * `grafana`:
   * `crds + chart` update 5.21.4 -> 5.24.0
   * `image` update 12.3.3 -> 12.4.4

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -37,6 +37,7 @@ argocd:
     cm:
       create: true
     params:
+      redis.compression: gzip
       server.insecure: true
 
   externalRedis:

--- a/charts/chart_deps/rabbitmq/rabbitmq-cluster/templates/clusters.yaml
+++ b/charts/chart_deps/rabbitmq/rabbitmq-cluster/templates/clusters.yaml
@@ -23,6 +23,9 @@ spec:
   resources:
   {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
+  {{- with .Values.terminationGracePeriodSeconds }}
+  terminationGracePeriodSeconds: {{ . }}
+  {{- end }}
   {{- with .Values.persistence }}
   persistence:
   {{- tpl (toYaml .) $ | nindent 4 }}
@@ -33,6 +36,10 @@ spec:
   {{- end }}
   {{- with .Values.affinity }}
   affinity:
+  {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  {{- with .Values.topologySpreadConstraints }}
+  topologySpreadConstraints:
   {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
   {{- with .Values.override }}

--- a/charts/chart_deps/rabbitmq/rabbitmq-cluster/values.yaml
+++ b/charts/chart_deps/rabbitmq/rabbitmq-cluster/values.yaml
@@ -4,20 +4,28 @@ nameOverride: ""
 prometheusSelector: {}
 annotations: {}
 replicas: 1
+terminationGracePeriodSeconds: 300
 rabbitmq:
   additionalConfig: |
     log.console.formatter = json
 persistence: {}
 tolerations: {}
 affinity: {}
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: '{{ include "rabbitmq-cluster.fullname" . }}'
 override: {}
 vhosts: {}
 serviceMonitor:
   metric_families:
-  - queue_coarse_metrics
-  - queue_metrics
-  - connection_churn_metrics
-  - node_metrics
-  - node_coarse_metrics
-  - channel_queue_exchange_metrics
-  - channel_queue_metrics
+    - queue_coarse_metrics
+    - queue_metrics
+    - connection_churn_metrics
+    - node_metrics
+    - node_coarse_metrics
+    - channel_queue_exchange_metrics
+    - channel_queue_metrics

--- a/charts/chart_deps/redis/redis-operated/templates/redis.yaml
+++ b/charts/chart_deps/redis/redis-operated/templates/redis.yaml
@@ -61,6 +61,9 @@ spec:
   {{- if $redis.readinessProbe }}
   readinessProbe: {{ toYaml $redis.readinessProbe | nindent 4 }}
   {{- end }}
+  {{- with $redis.terminationGracePeriodSeconds }}
+  terminationGracePeriodSeconds: {{ . }}
+  {{- end }}
 
   redisExporter:
     enabled: {{ $redisExporter.enabled }}
@@ -107,7 +110,7 @@ spec:
   tolerations: {{ toYaml $redis.tolerations | nindent 4 }}
   {{- end }}
   {{- if $redis.topologySpreadConstraints }}
-  topologySpreadConstraints: {{ toYaml $redis.topologySpreadConstraints | nindent 4 }}
+  topologySpreadConstraints: {{ tpl (toYaml $redis.topologySpreadConstraints) . | nindent 4 }}
   {{- end }}
   {{- if and $tls.ca $tls.cert $tls.key $tlsSecret.secretName }}
   TLS:

--- a/charts/chart_deps/redis/redis-operated/templates/sentinel.yaml
+++ b/charts/chart_deps/redis/redis-operated/templates/sentinel.yaml
@@ -77,6 +77,10 @@ spec:
     persistentVolumeClaimRetentionPolicy: {{ toYaml $sentinel.persistentVolumeClaimRetentionPolicy | nindent 6 }}
     {{- end }}
 
+  {{- with $sentinel.terminationGracePeriodSeconds }}
+  terminationGracePeriodSeconds: {{ . }}
+  {{- end }}
+
   redisExporter:
     enabled: {{ $redisExporter.enabled }}
     image: "{{ $redisExporter.image }}:{{ $redisExporter.tag }}"
@@ -110,7 +114,7 @@ spec:
   tolerations: {{ toYaml $sentinel.tolerations | nindent 4 }}
   {{- end }}
   {{- if $sentinel.topologySpreadConstraints }}
-  topologySpreadConstraints: {{ toYaml $sentinel.topologySpreadConstraints | nindent 4 }}
+  topologySpreadConstraints: {{ tpl (toYaml $sentinel.topologySpreadConstraints) . | nindent 4 }}
   {{- end }}
   {{- if and $tls.ca $tls.cert $tls.key $tlsSecret.secretName }}
   TLS:

--- a/charts/chart_deps/redis/redis-operated/values.yaml
+++ b/charts/chart_deps/redis/redis-operated/values.yaml
@@ -18,6 +18,7 @@ redis:
       memory: 15Mi
   ignoreAnnotations: []
   minReadySeconds: 0
+  terminationGracePeriodSeconds: 30
   recreateStatefulSetOnUpdateInvalid: false
   maxMemoryPercentOfLimit: 0
   persistentVolumeClaimRetentionPolicy: {}
@@ -39,7 +40,13 @@ redis:
     #        storage: 1Gi
   affinity: {}
   tolerations: []
-  topologySpreadConstraints: []
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app: '{{ include "redis-operated.clusterName" . }}'
   TLS:
     ca: ca.crt
     cert: tls.crt
@@ -124,6 +131,7 @@ sentinel:
       memory: 15Mi
   ignoreAnnotations: []
   minReadySeconds: 0
+  terminationGracePeriodSeconds: 30
   recreateStatefulSetOnUpdateInvalid: false
   persistentVolumeClaimRetentionPolicy: {}
   podSecurityContext:
@@ -134,7 +142,13 @@ sentinel:
   nodeSelector: {}
   affinity: {}
   tolerations: []
-  topologySpreadConstraints: []
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app: '{{ include "redis-operated.sentinelName" . }}-sentinel'
   TLS:
     ca: ca.crt
     cert: tls.crt

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -83,6 +83,17 @@ loki:
   ingress:
     enabled: false
   write:
+    affinity: null
+    terminationGracePeriodSeconds: 300
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: '{{ include "loki.name" . }}'
+            app.kubernetes.io/instance: '{{ .Release.Name }}'
+            app.kubernetes.io/component: write
     # -- Resource requests and limits for the write
     resources:
       requests:
@@ -92,6 +103,17 @@ loki:
         cpu: '3'
         memory: 4Gi
   read:
+    affinity: null
+    terminationGracePeriodSeconds: 30
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: '{{ include "loki.name" . }}'
+            app.kubernetes.io/instance: '{{ .Release.Name }}'
+            app.kubernetes.io/component: read
     # -- Resource requests and limits for the read
     resources:
       requests:
@@ -100,6 +122,17 @@ loki:
       limits:
         memory: 6Gi
   backend:
+    affinity: null
+    terminationGracePeriodSeconds: 300
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: '{{ include "loki.name" . }}'
+            app.kubernetes.io/instance: '{{ .Release.Name }}'
+            app.kubernetes.io/component: backend
     # -- Resource requests and limits for the backend
     resources:
       requests:


### PR DESCRIPTION
Enhancements:
* `argocd`:
  * explicitly enable `gzip` Redis cache compression for consistent cache keys across Argo CD components
* `redis`:
  * add templated `topologySpreadConstraints` for Redis and Sentinel pods to distribute replicas across available nodes
  * set `terminationGracePeriodSeconds` to 30 seconds for Redis and Sentinel pods
* `rabbitmq-cluster`:
  * add templated `topologySpreadConstraints` to distribute replicas across available nodes
  * set `terminationGracePeriodSeconds` to 300 seconds instead of the operator's seven-day default
* `loki`:
  * add templated `topologySpreadConstraints` for read, write and backend pods
  * disable default required pod anti-affinity so three replicas can be scheduled on two nodes
  * explicitly set termination grace periods to 30 seconds for read pods and 300 seconds for write and backend pods